### PR TITLE
Style: Card Atom - maxWidth responsive breakpoints 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dnovicki/dv-components",
-  "version": "2.3.2",
+  "version": "2.3.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11,38 +11,6 @@
       "dev": true,
       "requires": {
         "@babel/highlight": "7.0.0-beta.44"
-      }
-    },
-    "@babel/generator": {
-      "version": "7.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
-      "integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "7.0.0-beta.44",
-        "jsesc": "2.5.1",
-        "lodash": "4.17.10",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-          "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "lodash": "4.17.10",
-            "to-fast-properties": "2.0.0"
-          }
-        },
-        "jsesc": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
-          "dev": true
-        }
       }
     },
     "@babel/helper-annotate-as-pure": {
@@ -67,52 +35,6 @@
         }
       }
     },
-    "@babel/helper-function-name": {
-      "version": "7.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
-      "integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-get-function-arity": "7.0.0-beta.44",
-        "@babel/template": "7.0.0-beta.44",
-        "@babel/types": "7.0.0-beta.44"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-          "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "lodash": "4.17.10",
-            "to-fast-properties": "2.0.0"
-          }
-        }
-      }
-    },
-    "@babel/helper-get-function-arity": {
-      "version": "7.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
-      "integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "7.0.0-beta.44"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-          "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "lodash": "4.17.10",
-            "to-fast-properties": "2.0.0"
-          }
-        }
-      }
-    },
     "@babel/helper-module-imports": {
       "version": "7.0.0-beta.51",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.51.tgz",
@@ -120,28 +42,6 @@
       "requires": {
         "@babel/types": "7.0.0-beta.51",
         "lodash": "4.17.10"
-      }
-    },
-    "@babel/helper-split-export-declaration": {
-      "version": "7.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
-      "integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "7.0.0-beta.44"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-          "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "lodash": "4.17.10",
-            "to-fast-properties": "2.0.0"
-          }
-        }
       }
     },
     "@babel/highlight": {
@@ -203,89 +103,6 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
       "integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
       "dev": true
-    },
-    "@babel/template": {
-      "version": "7.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
-      "integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "7.0.0-beta.44",
-        "@babel/types": "7.0.0-beta.44",
-        "babylon": "7.0.0-beta.44",
-        "lodash": "4.17.10"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-          "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "lodash": "4.17.10",
-            "to-fast-properties": "2.0.0"
-          }
-        },
-        "babylon": {
-          "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
-          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
-          "dev": true
-        }
-      }
-    },
-    "@babel/traverse": {
-      "version": "7.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
-      "integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "7.0.0-beta.44",
-        "@babel/generator": "7.0.0-beta.44",
-        "@babel/helper-function-name": "7.0.0-beta.44",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.44",
-        "@babel/types": "7.0.0-beta.44",
-        "babylon": "7.0.0-beta.44",
-        "debug": "3.1.0",
-        "globals": "11.7.0",
-        "invariant": "2.2.4",
-        "lodash": "4.17.10"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-          "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "lodash": "4.17.10",
-            "to-fast-properties": "2.0.0"
-          }
-        },
-        "babylon": {
-          "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
-          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
-          "dev": true
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "globals": {
-          "version": "11.7.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
-          "dev": true
-        }
-      }
     },
     "@babel/types": {
       "version": "7.0.0-beta.51",
@@ -1574,23 +1391,97 @@
       }
     },
     "babel-eslint": {
-      "version": "8.2.6",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.6.tgz",
-      "integrity": "sha512-aCdHjhzcILdP8c9lej7hvXKvQieyRt20SF102SIGyY4cUIiw6UaAtK4j2o3dXX74jEmy0TJ0CEhv4fTIM3SzcA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.0.1.tgz",
+      "integrity": "sha512-h3moF6PCTQE06UjMMG+ydZSBvZ4Q7rqPE/5WAUOvUyHYUTqxm8JVhjZRiG1avI/tGVOK4BnZLDQapyLzh8DeKg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.44",
-        "@babel/traverse": "7.0.0-beta.44",
-        "@babel/types": "7.0.0-beta.44",
-        "babylon": "7.0.0-beta.44",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "1.0.0"
+        "babel-code-frame": "7.0.0-beta.0",
+        "babel-traverse": "7.0.0-beta.0",
+        "babel-types": "7.0.0-beta.0",
+        "babylon": "7.0.0-beta.22"
       },
       "dependencies": {
-        "@babel/types": {
-          "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-          "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.2"
+          }
+        },
+        "babel-code-frame": {
+          "version": "7.0.0-beta.0",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-beta.0.tgz",
+          "integrity": "sha512-/xr1ADm5bnTjjN+xwoXb7lF4v2rnxMzNZzFU7h8SxB+qB6+IqSTOOqVcpaPTUC2Non/MbQxS3OIZnJpQ2X21aQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.4.1",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          }
+        },
+        "babel-helper-function-name": {
+          "version": "7.0.0-beta.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.0.tgz",
+          "integrity": "sha512-DaQccFBBWBEzMdqbKmNXamY0m1yLHJGOdbbEsNoGdJrrU7wAF3wwowtDDPzF0ZT3SqJXPgZW/P2kgBX9moMuAA==",
+          "dev": true,
+          "requires": {
+            "babel-helper-get-function-arity": "7.0.0-beta.0",
+            "babel-template": "7.0.0-beta.0",
+            "babel-traverse": "7.0.0-beta.0",
+            "babel-types": "7.0.0-beta.0"
+          }
+        },
+        "babel-helper-get-function-arity": {
+          "version": "7.0.0-beta.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.0.tgz",
+          "integrity": "sha512-csqAic15/2Vm1951nJxkkL9K8E6ojyNF/eAOjk7pqJlO8kvgrccGNFCV9eDwcGHDPe5AjvJGwVSAcQ5fit9wuA==",
+          "dev": true,
+          "requires": {
+            "babel-types": "7.0.0-beta.0"
+          }
+        },
+        "babel-messages": {
+          "version": "7.0.0-beta.0",
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-7.0.0-beta.0.tgz",
+          "integrity": "sha512-eXdShsm9ZTh9AQhlIaAn6HR3xWpxCnK9ZwIDA9QyjnwTgMctGxHHflw4b4RJ3/ZjTL0Vrmvm0tQXPkp49mTAUw==",
+          "dev": true
+        },
+        "babel-template": {
+          "version": "7.0.0-beta.0",
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-7.0.0-beta.0.tgz",
+          "integrity": "sha512-tmdH+MmmU0F6Ur8humpevSmFzYKbrN3Oru0g5Qyg4R6+sxjnzZmnvzUbsP0aKMr7tB0Ua6xhEb9arKTOsEMkyA==",
+          "dev": true,
+          "requires": {
+            "babel-traverse": "7.0.0-beta.0",
+            "babel-types": "7.0.0-beta.0",
+            "babylon": "7.0.0-beta.22",
+            "lodash": "4.17.10"
+          }
+        },
+        "babel-traverse": {
+          "version": "7.0.0-beta.0",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-beta.0.tgz",
+          "integrity": "sha512-IKzuTqUcQtMRZ0Vv5RjIrGGj33eBKmNTNeRexWSyjPPuAciyNkva1rt7WXPfHfkb+dX7coRAIUhzeTUEzhnwdA==",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "7.0.0-beta.0",
+            "babel-helper-function-name": "7.0.0-beta.0",
+            "babel-messages": "7.0.0-beta.0",
+            "babel-types": "7.0.0-beta.0",
+            "babylon": "7.0.0-beta.22",
+            "debug": "3.1.0",
+            "globals": "10.4.0",
+            "invariant": "2.2.4",
+            "lodash": "4.17.10"
+          }
+        },
+        "babel-types": {
+          "version": "7.0.0-beta.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.0.tgz",
+          "integrity": "sha512-rJc2kV9iPJGLlqIY71AM3nPcdkoeLRCDuR07GFgfd3lFl4TsBQq76TxYQQIZ2MONg1HpsqmuoCXr9aZ1Oa4wYw==",
           "dev": true,
           "requires": {
             "esutils": "2.0.2",
@@ -1599,10 +1490,57 @@
           }
         },
         "babylon": {
-          "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
-          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+          "version": "7.0.0-beta.22",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.22.tgz",
+          "integrity": "sha512-Yl7iT8QGrS8OfR7p6R12AJexQm+brKwrryai4VWZ7NHUbPoZ5al3+klhvl/14shXZiLa7uK//OIFuZ1/RKHgoA==",
           "dev": true
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "10.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
+          "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
         }
       }
     },

--- a/src/atoms/card-content/card.js
+++ b/src/atoms/card-content/card.js
@@ -4,7 +4,7 @@ import { fontSize } from 'utils';
 import { flipOrder } from 'styles';
 import { space } from 'styled-system';
 
-export const Card = sys(
+export const CreateCard = sys(
 	{
 		border: '1px solid #ececec',
 		borderRadius: '3px',
@@ -12,17 +12,18 @@ export const Card = sys(
 		display: 'flex',
 		flexDirection: 'column',
 		flexWrap: 'nowrap',
-		maxWidth: [500, 500, 384],
 		color: '#2b2b2b'
 	},
 	'boxShadow',
 	'space',
 	'hover',
 	'flex',
-	() => `
-	transition: all .2s ease-in-out;
-`
+	'maxWidth'
 );
+
+export const Card = styled(CreateCard).attrs({ maxWidth: props => props.maxWidth || [500, 500, 384] })`
+	transition: all 0.2s ease -in -out;
+`;
 
 export const CardContainer = sys({
 	is: 'div',

--- a/src/atoms/card-content/card.js
+++ b/src/atoms/card-content/card.js
@@ -4,18 +4,25 @@ import { fontSize } from 'utils';
 import { flipOrder } from 'styles';
 import { space } from 'styled-system';
 
-export const Card = sys({
-	border: '1px solid #ececec',
-	borderRadius: '3px',
-	background: 'white',
-	display: 'flex',
-	flexDirection: 'column',
-	flexWrap: 'nowrap',
-	maxWidth: 500,
-	color: '#2b2b2b',
-}, 'boxShadow', 'space', 'hover', 'flex', () => `
+export const Card = sys(
+	{
+		border: '1px solid #ececec',
+		borderRadius: '3px',
+		background: 'white',
+		display: 'flex',
+		flexDirection: 'column',
+		flexWrap: 'nowrap',
+		maxWidth: [500, 500, 384],
+		color: '#2b2b2b'
+	},
+	'boxShadow',
+	'space',
+	'hover',
+	'flex',
+	() => `
 	transition: all .2s ease-in-out;
-`);
+`
+);
 
 export const CardContainer = sys({
 	is: 'div',
@@ -56,7 +63,7 @@ export const CardSubtitle = styled.h4.attrs({
 
 	color: #717171;
 	text-transform: uppercase;
-	letter-spacing: .04rem;
+	letter-spacing: 0.04rem;
 `;
 
 export const CardHeader = styled.header`
@@ -73,10 +80,13 @@ export const CardText = styled.p.attrs({
 	line-height: 1.5;
 `;
 
-export const CardFooter = sys({
-	is: 'footer',
-	pt: 3,
-	mt: 'auto',
-	gridRowStart: 2,
-	gridRowEnd: 3
-}, 'width');
+export const CardFooter = sys(
+	{
+		is: 'footer',
+		pt: 3,
+		mt: 'auto',
+		gridRowStart: 2,
+		gridRowEnd: 3
+	},
+	'width'
+);

--- a/src/atoms/card-content/card.js
+++ b/src/atoms/card-content/card.js
@@ -1,5 +1,6 @@
 import sys from 'system-components';
 import styled from 'styled-components';
+import { createSkeletonElement } from '@trainline/react-skeletor';
 import { fontSize } from 'utils';
 import { flipOrder } from 'styles';
 import { space } from 'styled-system';
@@ -33,7 +34,7 @@ export const CardContainer = sys({
 	height: '100%'
 });
 
-export const CardImage = sys({
+const makeCardImage = sys({
 	is: 'img',
 	p: 0,
 	mt: '-1px',
@@ -43,7 +44,9 @@ export const CardImage = sys({
 	width: 'calc(100% + 2px)'
 });
 
-export const CardTitle = styled.h3.attrs({
+export const CardImage = createSkeletonElement(makeCardImage);
+
+const makeCardTitle = styled.h3.attrs({
 	fontSize: [2, 3],
 	pb: 2,
 	m: 0
@@ -54,7 +57,9 @@ export const CardTitle = styled.h3.attrs({
 	font-weight: 700;
 `;
 
-export const CardSubtitle = styled.h4.attrs({
+export const CardTitle = createSkeletonElement(makeCardTitle);
+
+const makeCardSubtitle = styled.h4.attrs({
 	fontSize: [0, 1],
 	pb: 1,
 	m: 0
@@ -67,11 +72,13 @@ export const CardSubtitle = styled.h4.attrs({
 	letter-spacing: 0.04rem;
 `;
 
+export const CardSubtitle = createSkeletonElement(makeCardSubtitle);
+
 export const CardHeader = styled.header`
 	${flipOrder};
 `;
 
-export const CardText = styled.p.attrs({
+const makeCardText = styled.p.attrs({
 	fontSize: 1,
 	m: 0
 })`
@@ -81,7 +88,9 @@ export const CardText = styled.p.attrs({
 	line-height: 1.5;
 `;
 
-export const CardFooter = sys(
+export const CardText = createSkeletonElement(makeCardText);
+
+const makeCardFooter = sys(
 	{
 		is: 'footer',
 		pt: 3,
@@ -91,3 +100,5 @@ export const CardFooter = sys(
 	},
 	'width'
 );
+
+export const CardFooter = createSkeletonElement(makeCardFooter);

--- a/src/atoms/section-content/section-container.js
+++ b/src/atoms/section-content/section-container.js
@@ -6,14 +6,12 @@ import { themeGet } from 'styled-system';
 
 const SystemSection = sys('color', 'flex', 'flexWrap', 'flexDirection', 'justifyContent', 'alignItems', 'space', 'maxWidth', 'display');
 
-const SectionContainer = styled(({
-	content, /* eslint-disable-line */
-	centered, /* eslint-disable-line */
-	backgroundImage, /* eslint-disable-line */
-	children,
-	...props
-}) => <SystemSection {...props}>{children}</SystemSection>).attrs({
-	py: props => props.py ||[5, 4, 6],
+const SectionContainer = styled(
+	({ content /* eslint-disable-line */, centered /* eslint-disable-line */, backgroundImage /* eslint-disable-line */, children, ...props }) => (
+		<SystemSection {...props}>{children}</SystemSection>
+	)
+).attrs({
+	py: props => props.py || [5, 4, 6],
 	px: props => props.px || [3, 4, 6],
 	m: props => props.m || 0,
 	is: props => props.is || 'section',
@@ -23,20 +21,25 @@ const SectionContainer = styled(({
 	flex-flow: column nowrap;
 	align-items: center;
 
-	${props => props.backgroundImage ? `
+	${props =>
+		props.backgroundImage
+			? `
 		background-image: url('${props.backgroundImage.url}');
 		background-repeat: ${props.backgroundImage.pattern ? 'repeat' : 'no-repeat'};
 		background-size: ${props.backgroundImage.pattern ? props.backgroundImage.size || 'auto' : 'cover'};
 		background-position: ${props.backgroundImage.position || 'center center'};
 		background-color: ${props => themeGet(`colors.${props.backgroundImage.color}`, 'transparent')};
-	` : `
+	`
+			: `
 		background: ${props => themeGet(`backgrounds.${props.type}`, 'transparent')};
 	`};
-	${props => props.centered && `
+	${props =>
+		props.centered &&
+		`
 		margin-left: auto !important;
 		margin-right: auto !important;
 	`};
-	${props => props.content ? 'max-width: 1200px': ''};
+	${props => (props.content ? 'max-width: 1200px' : '')};
 `;
 
 SectionContainer.propTypes = {

--- a/src/organism/templates/card-row.js
+++ b/src/organism/templates/card-row.js
@@ -1,22 +1,23 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {
-	FlexBox, Card, CardImage, CardContainer, CardHeader, CardTitle, CardSubtitle, CardFooter, LinkWrapper, Content
-} from 'atoms';
+import { FlexBox, Card, CardImage, CardContainer, CardHeader, CardTitle, CardSubtitle, CardFooter, LinkWrapper, Content } from 'atoms';
 import { Section, ArticleListHeader } from 'molecules';
 
 export default class CardRow extends Component {
 	static propTypes = {
-		articles: PropTypes.arrayOf(PropTypes.shape({
-			imageAttributes: PropTypes.shape({
-				src: PropTypes.string.isRequired,
-				alt: PropTypes.string.isRequired
-			}),
-			to: PropTypes.string.isRequired,
-			title: PropTypes.string.isRequired,
-			subtitleLink: PropTypes.string,
-			subtitle: PropTypes.string
-		})),
+		articles: PropTypes.arrayOf(
+			PropTypes.shape({
+				imageAttributes: PropTypes.shape({
+					src: PropTypes.string.isRequired,
+					alt: PropTypes.string.isRequired
+				}),
+				to: PropTypes.string.isRequired,
+				title: PropTypes.string.isRequired,
+				subtitleLink: PropTypes.string,
+				subtitle: PropTypes.string,
+				cardAttributes: PropTypes.object
+			})
+		),
 		renderFooter: PropTypes.func,
 		headerAttributes: PropTypes.shape({
 			title: PropTypes.string,
@@ -27,7 +28,7 @@ export default class CardRow extends Component {
 		showAll: PropTypes.bool,
 		description: PropTypes.string,
 		footerProps: PropTypes.arrayOf(PropTypes.string)
-	}
+	};
 
 	static defaultProps = {
 		renderFooter: () => {},
@@ -35,21 +36,21 @@ export default class CardRow extends Component {
 		showAll: false,
 		description: null,
 		headerAttributes: null
-	}
+	};
 
-	pluckProps = (footerProps, props) => Object
-		.keys(props)
-		.filter(x => footerProps.includes(x))
-		.reduce((acc, curr) => ({ ...acc, [curr]: props[curr] }), {});
+	pluckProps = (footerProps, props) =>
+		Object.keys(props)
+			.filter(x => footerProps.includes(x))
+			.reduce((acc, curr) => ({ ...acc, [curr]: props[curr] }), {});
 
-	renderFooter = (article) => {
+	renderFooter = article => {
 		const { footerProps, renderFooter } = this.props;
 		const renderProps = this.pluckProps(footerProps, article);
 		return renderFooter(renderProps);
-	}
+	};
 
 	renderArticleRow = ({ ...article }) => (
-		<Card mx={2} my={3} flex="1 300px">
+		<Card mx={2} my={3} flex="1 300px" {...article.cardAttributes}>
 			{article.imageAttributes && (
 				<LinkWrapper to={article.to}>
 					<CardImage {...article.imageAttributes} />
@@ -73,54 +74,36 @@ export default class CardRow extends Component {
 				)}
 			</CardContainer>
 		</Card>
-	)
+	);
 
 	render = () => {
-		const {
-			articles,
-			showAll,
-			headerAttributes,
-			footerProps,
-			renderFooter,
-			description,
-			...props
-		} = this.props;
+		const { articles, showAll, headerAttributes, footerProps, renderFooter, description, ...props } = this.props;
 
-		const rowArticles = showAll ?
-			articles.map(this.renderArticleRow) :
-			articles
-				.slice(0, 3)
-				.map(this.renderArticleRow);
+		const rowArticles = showAll ? articles.map(this.renderArticleRow) : articles.slice(0, 3).map(this.renderArticleRow);
 
-		const buttonAttributes = headerAttributes ? {
-			...headerAttributes.buttonAttributes,
-			buttonLeft: false,
-			small: true,
-			type: 'primary',
-			noButtonSpacing: true,
-			nostyle: true
-		} : undefined;
+		const buttonAttributes = headerAttributes
+			? {
+				...headerAttributes.buttonAttributes,
+				buttonLeft: false,
+				small: true,
+				type: 'primary',
+				noButtonSpacing: true,
+				nostyle: true
+			  }
+			: undefined;
 
 		return (
-			<Section
-				{...props}
-				bodyAttributes={{ width: '100%' }}
-				centered
-				content
-				buttonAttributes={buttonAttributes}
-			>
-				{headerAttributes && (<ArticleListHeader {...headerAttributes} />)}
-				{description && <Content mt={3} mb={2}>{description}</Content>}
-				<FlexBox
-					display="flex"
-					flexDirection="row"
-					flexWrap="wrap"
-					justifyContent="center"
-					alignItems="stretch"
-				>
+			<Section {...props} bodyAttributes={{ width: '100%' }} centered content buttonAttributes={buttonAttributes}>
+				{headerAttributes && <ArticleListHeader {...headerAttributes} />}
+				{description && (
+					<Content mt={3} mb={2}>
+						{description}
+					</Content>
+				)}
+				<FlexBox display="flex" flexDirection="row" flexWrap="wrap" justifyContent="center" alignItems="stretch">
 					{rowArticles}
 				</FlexBox>
 			</Section>
 		);
-	}
+	};
 }

--- a/src/organism/templates/docs/card-row.md
+++ b/src/organism/templates/docs/card-row.md
@@ -2,13 +2,13 @@
 
 A listing of articles used for templates
 
-- [x] Allows Skeleton Loading
+-   [x] Allows Skeleton Loading
 
 ## Usage
+
 Render footer is passed the props that are defined in footer props. These props are [plucked](https://ramdajs.com/docs/#pluck) from
 the articles object. The render footer function then can be given a function that returns a JSX object that will render underneath the
 article title.
-
 
 ```javascript
 import { Organisms } from '@dnovicki/dv-components';
@@ -49,8 +49,9 @@ const article = {
 ```
 
 ## Custom PropTypes
+
 | property         | propType         | required | default | description                                                                                       |
-|:-----------------|:-----------------|:---------|:--------|:--------------------------------------------------------------------------------------------------|
+| :--------------- | :--------------- | :------- | :------ | :------------------------------------------------------------------------------------------------ |
 | articles         | [articles]       | true     |         | array of articles to list                                                                         |
 | description      | string           | false    |         | text that appears underneath the article list header                                              |
 | headerAttributes | headerAttributes | false    | null    | attributes that are passed directly to the article list header                                    |
@@ -59,35 +60,46 @@ const article = {
 | showAll          | boolean          | false    | false   | normally the listing of cards is limited to three, this will create unlimited amount of card rows |
 
 ### articles
+
 | property        | propType        | required | default | description                                                       |
-|:----------------|:----------------|:---------|:--------|:------------------------------------------------------------------|
+| :-------------- | :-------------- | :------- | :------ | :---------------------------------------------------------------- |
 | title           | string          | true     |         | title of article                                                  |
 | to              | string          | true     |         | internal link to article                                          |
 | imageAttributes | imageAttributes | true     |         | image information                                                 |
 | subtitle        | string          | false    | null    | subtitle text to appear above article title                       |
 | subtitle link   | string          | false    | null    | link that wraps around the subtitle (typically for category urls) |
 | description     | string          | false    | null    | text to appear underneath the title                               |
+| cardAttributes  | cardAttributes  | false    |         | card styles                                                       |
 
 ### imageAttributes
+
 Any [valid img attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img) can be passed to this object to an img tag.
 
 | property | propType | required | default | description    |
-|:---------|:---------|:---------|:--------|:---------------|
+| :------- | :------- | :------- | :------ | :------------- |
 | src      | string   | true     |         | image url      |
 | alt      | string   | true     |         | image alt text |
 
+## cardAttributes
+
+| property | propType | required | default         | description                      |
+| :------- | :------- | :------- | :-------------- | :------------------------------- |
+| maxWidth | array    | false    | [500, 500, 384] | breakpoints for card's max-width |
+
 ### headerAttributes
+
 Attributes that are passed directly to the article list header (the bar the appears above the listing of articles)
-| property         | propType         | required | default | description                                                                              |
+| property | propType | required | default | description |
 |:-----------------|:-----------------|:---------|:--------|:-----------------------------------------------------------------------------------------|
-| title            | string           | false    | null    | text that appears on the left side of the bar                                            |
-| buttonAttributes | buttonAttributes | false    | null    | button attributes passed to the button element that appears on the right side of the bar |
+| title | string | false | null | text that appears on the left side of the bar |
+| buttonAttributes | buttonAttributes | false | null | button attributes passed to the button element that appears on the right side of the bar |
 
 ### buttonAttributes
+
 one of href or to is required
 
 | property | propType | required | default | description                       |
-|:---------|:---------|:---------|:--------|:----------------------------------|
+| :------- | :------- | :------- | :------ | :-------------------------------- |
 | to       | string   | X        |         | internal url for link             |
 | href     | string   | X        |         | external url for link             |
 | text     | string   | true     |         | string that appears in the button |

--- a/src/organism/templates/docs/lifestyle.md
+++ b/src/organism/templates/docs/lifestyle.md
@@ -3,13 +3,13 @@
 A listing of articles used for templates. Use only for lifestyle articles (used to be known as Skintegrative). This is for articles
 that are not necessarily scientific or data driven, but are more like Top 10 things to do when you have acne kinda thing.
 
-- [x] Allows Skeleton Loading
+-   [x] Allows Skeleton Loading
 
 ## Usage
+
 Render footer is passed the props that are defined in footer props. These props are [plucked](https://ramdajs.com/docs/#pluck) from
 the articles object. The render footer function then can be given a function that returns a JSX object that will render underneath the
 article title.
-
 
 ```javascript
 import { Organisms } from '@dnovicki/dv-components';
@@ -50,8 +50,9 @@ const article = {
 ```
 
 ## Custom PropTypes
+
 | property         | propType         | required | default | description                                                                                       |
-|:-----------------|:-----------------|:---------|:--------|:--------------------------------------------------------------------------------------------------|
+| :--------------- | :--------------- | :------- | :------ | :------------------------------------------------------------------------------------------------ |
 | articles         | [articles]       | true     |         | array of articles to list                                                                         |
 | description      | string           | false    |         | text that appears underneath the article list header                                              |
 | headerAttributes | headerAttributes | false    | null    | attributes that are passed directly to the article list header                                    |
@@ -60,35 +61,46 @@ const article = {
 | showAll          | boolean          | false    | false   | normally the listing of cards is limited to three, this will create unlimited amount of card rows |
 
 ### articles
+
 | property        | propType        | required | default | description                                                       |
-|:----------------|:----------------|:---------|:--------|:------------------------------------------------------------------|
+| :-------------- | :-------------- | :------- | :------ | :---------------------------------------------------------------- |
 | title           | string          | true     |         | title of article                                                  |
 | to              | string          | true     |         | internal link to article                                          |
 | imageAttributes | imageAttributes | true     |         | image information                                                 |
 | subtitle        | string          | false    | null    | subtitle text to appear above article title                       |
 | subtitle link   | string          | false    | null    | link that wraps around the subtitle (typically for category urls) |
 | description     | string          | false    | null    | text to appear underneath the title                               |
+| cardAttributes  | cardAttributes  | false    |         | card styles                                                       |
 
 ### imageAttributes
+
 Any [valid img attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img) can be passed to this object to an img tag.
 
 | property | propType | required | default | description    |
-|:---------|:---------|:---------|:--------|:---------------|
+| :------- | :------- | :------- | :------ | :------------- |
 | src      | string   | true     |         | image url      |
 | alt      | string   | true     |         | image alt text |
 
+## cardAttributes
+
+| property | propType | required | default         | description                      |
+| :------- | :------- | :------- | :-------------- | :------------------------------- |
+| maxWidth | array    | false    | [500, 500, 384] | breakpoints for card's max-width |
+
 ### headerAttributes
+
 Attributes that are passed directly to the article list header (the bar the appears above the listing of articles)
-| property         | propType         | required | default | description                                                                              |
+| property | propType | required | default | description |
 |:-----------------|:-----------------|:---------|:--------|:-----------------------------------------------------------------------------------------|
-| title            | string           | false    | null    | text that appears on the left side of the bar                                            |
-| buttonAttributes | buttonAttributes | false    | null    | button attributes passed to the button element that appears on the right side of the bar |
+| title | string | false | null | text that appears on the left side of the bar |
+| buttonAttributes | buttonAttributes | false | null | button attributes passed to the button element that appears on the right side of the bar |
 
 ### buttonAttributes
+
 one of href or to is required
 
 | property | propType | required | default | description                       |
-|:---------|:---------|:---------|:--------|:----------------------------------|
+| :------- | :------- | :------- | :------ | :-------------------------------- |
 | to       | string   | X        |         | internal url for link             |
 | href     | string   | X        |         | external url for link             |
 | text     | string   | true     |         | string that appears in the button |

--- a/src/organism/templates/lifestyle.js
+++ b/src/organism/templates/lifestyle.js
@@ -2,9 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import btoa from 'btoa';
 import { Wiggle } from 'img';
-import {
-	Card, CardImage, CardContainer, CardHeader, CardTitle, CardSubtitle, CardFooter, LinkWrapper, FlexBox, Content
-} from 'atoms';
+import { Card, CardImage, CardContainer, CardHeader, CardTitle, CardSubtitle, CardFooter, LinkWrapper, FlexBox, Content } from 'atoms';
 import { Section } from 'molecules';
 
 const cardContentStyles = {
@@ -19,16 +17,19 @@ const cardContentStyles = {
 
 export default class CardRow extends Component {
 	static propTypes = {
-		articles: PropTypes.arrayOf(PropTypes.shape({
-			imageAttributes: PropTypes.shape({
-				src: PropTypes.string.isRequired,
-				alt: PropTypes.string.isRequired
-			}),
-			to: PropTypes.string.isRequired,
-			title: PropTypes.string.isRequired,
-			subtitleLink: PropTypes.string,
-			subtitle: PropTypes.string
-		})),
+		articles: PropTypes.arrayOf(
+			PropTypes.shape({
+				imageAttributes: PropTypes.shape({
+					src: PropTypes.string.isRequired,
+					alt: PropTypes.string.isRequired
+				}),
+				to: PropTypes.string.isRequired,
+				title: PropTypes.string.isRequired,
+				subtitleLink: PropTypes.string,
+				subtitle: PropTypes.string,
+				cardAttributes: PropTypes.object
+			})
+		),
 		renderFooter: PropTypes.func,
 		headerAttributes: PropTypes.shape({
 			title: PropTypes.string,
@@ -39,7 +40,7 @@ export default class CardRow extends Component {
 		showAll: PropTypes.bool,
 		description: PropTypes.string,
 		footerProps: PropTypes.arrayOf(PropTypes.string)
-	}
+	};
 
 	static defaultProps = {
 		renderFooter: () => {},
@@ -47,21 +48,21 @@ export default class CardRow extends Component {
 		showAll: false,
 		description: null,
 		headerAttributes: null
-	}
+	};
 
-	pluckProps = (footerProps, props) => Object
-		.keys(props)
-		.filter(x => footerProps.includes(x))
-		.reduce((acc, curr) => ({ ...acc, [curr]: props[curr] }), {});
+	pluckProps = (footerProps, props) =>
+		Object.keys(props)
+			.filter(x => footerProps.includes(x))
+			.reduce((acc, curr) => ({ ...acc, [curr]: props[curr] }), {});
 
-	renderFooter = (article) => {
+	renderFooter = article => {
 		const { footerProps, renderFooter } = this.props;
 		const renderProps = this.pluckProps(footerProps, article);
 		return renderFooter(renderProps);
-	}
+	};
 
 	renderArticleRow = ({ ...article }) => (
-		<Card mx={2} my={3} boxShadow={1} flex="1 300px" hover={{ boxShadow: 2 }}>
+		<Card mx={2} my={3} boxShadow={1} flex="1 300px" hover={{ boxShadow: 2 }} {...article.cardAttributes}>
 			{article.imageAttributes && (
 				<LinkWrapper to={article.to}>
 					<CardImage {...article.imageAttributes} />
@@ -78,38 +79,24 @@ export default class CardRow extends Component {
 						</LinkWrapper>
 					)}
 				</CardHeader>
-				{this.renderFooter && (
-					<CardFooter width="100%">
-						{this.renderFooter(article)}
-					</CardFooter>
-				)}
+				{this.renderFooter && <CardFooter width="100%">{this.renderFooter(article)}</CardFooter>}
 			</CardContainer>
 		</Card>
-	)
+	);
 
 	render = () => {
-		const {
-			articles,
-			headerAttributes,
-			description,
-			footerProps,
-			showAll,
-			renderFooter,
-			...props
-		} = this.props;
+		const { articles, headerAttributes, description, footerProps, showAll, renderFooter, ...props } = this.props;
 
-		const rowArticles = showAll ?
-			articles.map(this.renderArticleRow) :
-			articles
-				.slice(0, 3)
-				.map(this.renderArticleRow);
+		const rowArticles = showAll ? articles.map(this.renderArticleRow) : articles.slice(0, 3).map(this.renderArticleRow);
 
-		const buttonAttributes = headerAttributes ? {
-			...headerAttributes.buttonAttributes,
-			buttonLeft: false,
-			small: true,
-			type: 'primary'
-		} : undefined;
+		const buttonAttributes = headerAttributes
+			? {
+				...headerAttributes.buttonAttributes,
+				buttonLeft: false,
+				small: true,
+				type: 'primary'
+			  }
+			: undefined;
 
 		return (
 			<Section
@@ -131,24 +118,12 @@ export default class CardRow extends Component {
 					pb: 1,
 					color: 'accent.tertiary',
 					fontWeight: 400
-				}}
-			>
-				{description && (
-					<Content {...cardContentStyles}>
-						{description}
-					</Content>
-				)}
-				<FlexBox
-					display="flex"
-					flexDirection="row"
-					pt={4}
-					flexWrap="wrap"
-					justifyContent="center"
-					alignItems="stretch"
-				>
+				}}>
+				{description && <Content {...cardContentStyles}>{description}</Content>}
+				<FlexBox display="flex" flexDirection="row" pt={4} flexWrap="wrap" justifyContent="center" alignItems="stretch">
 					{rowArticles}
 				</FlexBox>
 			</Section>
 		);
-	}
+	};
 }


### PR DESCRIPTION
This PR solves the issue when there is an unbalanced number of cards in the CardRow component when showing all and the last row displayed larger cards because of the flex property.

**Steps to Test:**

- Run Storybook.
- Go to Organisms > Templates > CardRow.
- Under knobs, check showAll.
- In large/xl view, expect that the last 2 cards are in their own row and match the size of the cards in the first row.
- In tablet view, expect that the cards are wide in width (500px).
- In mobile view, expect that the cards are wide in width (500px).