### PR TITLE
Style: image list item and section

### DIFF
--- a/src/atoms/link-wrapper/docs/link-wrapper.md
+++ b/src/atoms/link-wrapper/docs/link-wrapper.md
@@ -19,6 +19,22 @@ this will output the following html:
 </a>
 ```
 
+### With external link
+```javascript
+import { Atoms } from '@dnovicki/dv-components';
+
+<Atoms.LinkWrapper href="http://google.com" target="_blank" rel="noopener noreferrer">
+	<div>i am a link</div>
+</Atoms.LinkWrapper>
+```
+
+this will output the following html:
+```html
+<a href="http://localhost/tester">
+	<div>i am a link</div>
+</a>
+```
+
 ### Without internal Link
 ```javascript
 import { Atoms } from '@dnovicki/dv-components';

--- a/src/atoms/link-wrapper/link-wrapper.js
+++ b/src/atoms/link-wrapper/link-wrapper.js
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom';
 const NoStyleLink = styled(Link)`
 	color: inherit;
 	text-decoration: none;
+	cursor: pointer;
 
 	display: block;
 	&:hover {
@@ -16,9 +17,14 @@ const NoStyleLink = styled(Link)`
 	${height};
 `;
 
-const LinkWrapper = ({ to, children, ...props }) => to ?
-	<NoStyleLink {...props} to={to}>{children}</NoStyleLink> :
-	<React.Fragment>{children}</React.Fragment>;
+const LinkWrapper = ({ to, children, ...props }) =>
+	to ? (
+		<NoStyleLink {...props} to={to}>
+			{children}
+		</NoStyleLink>
+	) : (
+		<React.Fragment>{children}</React.Fragment>
+	);
 
 LinkWrapper.propTypes = {
 	to: PropTypes.string,

--- a/src/atoms/link-wrapper/link-wrapper.js
+++ b/src/atoms/link-wrapper/link-wrapper.js
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { height } from 'styled-system';
 import { Link } from 'react-router-dom';
 
-const NoStyleLink = styled(Link)`
+const ExternalLink = styled('a')`
 	color: inherit;
 	text-decoration: none;
 	cursor: pointer;
@@ -17,17 +17,27 @@ const NoStyleLink = styled(Link)`
 	${height};
 `;
 
-const LinkWrapper = ({ to, children, ...props }) =>
-	to ? (
-		<NoStyleLink {...props} to={to}>
-			{children}
-		</NoStyleLink>
-	) : (
-		<React.Fragment>{children}</React.Fragment>
-	);
+const InternalLink = ExternalLink.withComponent(Link);
+
+const LinkWrapper = ({ to, href, children, ...props }) => {
+	if (to)
+		return (
+			<InternalLink to={to} {...props}>
+				{children}
+			</InternalLink>
+		);
+	else if (href)
+		return (
+			<ExternalLink href={href} {...props} target="_blank" rel="noopener noreferrer">
+				{children}
+			</ExternalLink>
+		);
+	return <React.Fragment>{children}</React.Fragment>;
+};
 
 LinkWrapper.propTypes = {
 	to: PropTypes.string,
+	href: PropTypes.string,
 	children: PropTypes.node.isRequired
 };
 

--- a/src/atoms/link-wrapper/link-wrapper.stories.js
+++ b/src/atoms/link-wrapper/link-wrapper.stories.js
@@ -10,13 +10,19 @@ import LinkWrapperReadme from './docs/link-wrapper.md';
 import LinkWrapper from './link-wrapper';
 
 storiesOf('Atoms/Link Wrapper', module)
-	.add('with link', withReadme(LinkWrapperReadme, () => (
+	.addDecorator(withReadme(LinkWrapperReadme))
+	.add('with internal link', () => (
 		<LinkWrapper to="/test">
 			<div>no style link</div>
 		</LinkWrapper>
-	)))
-	.add('with no link', withReadme(LinkWrapperReadme, () => (
+	))
+	.add('with external link', () => (
+		<LinkWrapper href="http://google.com">
+			<div>no style link</div>
+		</LinkWrapper>
+	))
+	.add('with no link', () => (
 		<LinkWrapper>
 			<div>simple div</div>
 		</LinkWrapper>
-	)));
+	));

--- a/src/atoms/list-item-content/list-item-content.js
+++ b/src/atoms/list-item-content/list-item-content.js
@@ -6,7 +6,7 @@ import { fontSize } from 'utils';
 import { IconCircle } from 'atoms';
 
 const makeListItemTitle = styled.h3.attrs({
-	fontSize: [1, 2],
+	fontSize: props => props.fontSize || [1, 2],
 	lineHeight: 2,
 	pb: 3,
 	m: 0

--- a/src/atoms/list-item-content/list-item-content.js
+++ b/src/atoms/list-item-content/list-item-content.js
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
-import { space, themeGet, lineHeight } from 'styled-system';
+import { space, themeGet, lineHeight, width, flex } from 'styled-system';
 import { createSkeletonElement } from '@trainline/react-skeletor';
 import { flipOrder } from 'styles';
 import { fontSize } from 'utils';
 import { IconCircle } from 'atoms';
 
 const makeListItemTitle = styled.h3.attrs({
-	fontSize: [3, 4],
+	fontSize: [1, 2],
 	lineHeight: 2,
 	pb: 3,
 	m: 0
@@ -14,6 +14,7 @@ const makeListItemTitle = styled.h3.attrs({
 	${space};
 	${lineHeight};
 	${fontSize};
+	font-weight: 600;
 	font-family: ${themeGet('fonts.display', 'serif')};
 `;
 export const ListItemTitle = createSkeletonElement(makeListItemTitle);
@@ -30,12 +31,14 @@ const makeListItemBody = styled.p.attrs({
 `;
 export const ListItemBody = createSkeletonElement(makeListItemBody);
 
-export const ListItemContainer = styled.li`
+export const ListItemContainer = styled.li.attrs({
+	flex: props => props.flex || '1 250px'
+})`
 	${space};
-	display: flex;
-	flex-flow: column nowrap;
-	align-items: flex-start;
-	background: ${props => themeGet(`backgrounds.${props.type}`, 'transparent')}
+	${width};
+	${flex};
+	display: block;
+	background: ${props => themeGet(`backgrounds.${props.type}`, 'transparent')};
 `;
 
 const makeListItemImage = styled.img`
@@ -60,7 +63,7 @@ export const BulletItem = styled.span.attrs({
 	align-items: center;
 	justify-content: center;
 	color: white;
-	background: ${props => themeGet(`backgrounds.${props.type}`, 'white')}
+	background: ${props => themeGet(`backgrounds.${props.type}`, 'white')};
 `;
 
 export const BulletIcon = styled(IconCircle).attrs({

--- a/src/atoms/section-content/section-content.js
+++ b/src/atoms/section-content/section-content.js
@@ -2,10 +2,16 @@ import sys from 'system-components';
 import styled from 'styled-components';
 import { fontSize } from 'utils';
 
-const makeSectionTitle = sys({
-	fontWeight: 700,
-	m: 0
-}, 'color', 'textAlign', 'fontFamily', 'lineHeight');
+const makeSectionTitle = sys(
+	{
+		fontWeight: 700,
+		m: 0
+	},
+	'color',
+	'textAlign',
+	'fontFamily',
+	'lineHeight'
+);
 
 export const SectionTitle = styled(makeSectionTitle).attrs({
 	fontSize: props => props.fontSize || [4, 5],
@@ -18,10 +24,10 @@ export const SectionTitle = styled(makeSectionTitle).attrs({
 	${fontSize};
 `;
 
-const makeSectionBody = sys('color', 'flex', 'flexWrap', 'flexDirection', 'justifyContent', 'alignItems', 'space' ,'width');
+const makeSectionBody = sys('color', 'flex', 'display', 'flexWrap', 'flexDirection', 'justifyContent', 'alignItems', 'space', 'width');
 
 export const SectionBody = styled(makeSectionBody).attrs({
-	fontSize: props => props.fontSize || [1, 2],
+	fontSize: props => props.fontSize || [1, 2]
 })`
 	${fontSize};
 `;

--- a/src/molecules/list-item/icon-list-item.js
+++ b/src/molecules/list-item/icon-list-item.js
@@ -8,7 +8,8 @@ import {
 	IconCircle,
 	ArrowButton,
 	Subtitle,
-	ArrowButtonLink
+	ArrowButtonLink,
+	LinkWrapper
 } from 'atoms';
 
 class IconListItem extends Component {
@@ -17,6 +18,8 @@ class IconListItem extends Component {
 		iconAttributes: PropTypes.shape({
 			name: PropTypes.string.isRequired
 		}).isRequired,
+		to: PropTypes.string,
+		href: PropTypes.string,
 		subtitle: PropTypes.string,
 		children: PropTypes.node.isRequired,
 		buttonAttributes: PropTypes.shape({
@@ -39,17 +42,19 @@ class IconListItem extends Component {
 	)
 
 	render() {
-		const { iconAttributes, buttonAttributes, title, children, subtitle, ...attrs } = this.props;
+		const { iconAttributes, to, href, buttonAttributes, title, children, subtitle, ...attrs } = this.props;
 		const { text, ...buttonProps } = buttonAttributes;
 
 		return (
 			<ListItemContainer {...attrs}>
-				<IconCircle {...iconAttributes} />
-				<ListItemHeader mt={3}>
-					<ListItemTitle>{title}</ListItemTitle>
-					{subtitle && <Subtitle pb={1} color="#717171">{subtitle}</Subtitle>}
-				</ListItemHeader>
-				<ListItemBody>{children}</ListItemBody>
+				<LinkWrapper to={to} href={href}>
+					<IconCircle {...iconAttributes} />
+					<ListItemHeader mt={3}>
+						<ListItemTitle>{title}</ListItemTitle>
+						{subtitle && <Subtitle pb={1} color="#717171">{subtitle}</Subtitle>}
+					</ListItemHeader>
+					<ListItemBody>{children}</ListItemBody>
+				</LinkWrapper>
 				{text && this.renderButton(buttonProps, text)}
 			</ListItemContainer>
 		);

--- a/src/molecules/list-item/image-list-item.js
+++ b/src/molecules/list-item/image-list-item.js
@@ -17,6 +17,7 @@ class ImageListItem extends Component {
 		title: PropTypes.string.isRequired,
 		subtitle: PropTypes.string,
 		to: PropTypes.string,
+		href: PropTypes.string,
 		imageAttributes: PropTypes.shape({
 			src: PropTypes.string.isRequired,
 			alt: PropTypes.string.isRequired
@@ -45,12 +46,12 @@ class ImageListItem extends Component {
 		);
 
 	render() {
-		const { imageAttributes, buttonAttributes, title, subtitle, children, to, ...attrs } = this.props;
+		const { imageAttributes, buttonAttributes, title, subtitle, children, to, href, ...attrs } = this.props;
 		const { text, ...buttonProps } = buttonAttributes;
 
 		return (
 			<ListItemContainer {...attrs}>
-				<LinkWrapper to={to}>
+				<LinkWrapper to={to} href={href}>
 					<ListItemImage {...imageAttributes} />
 					<ListItemHeader mt={3}>
 						<ListItemTitle>{title}</ListItemTitle>

--- a/src/molecules/list-item/image-list-item.js
+++ b/src/molecules/list-item/image-list-item.js
@@ -62,8 +62,8 @@ class ImageListItem extends Component {
 						)}
 					</ListItemHeader>
 					<ListItemBody>{children}</ListItemBody>
-					{text && this.renderButton(buttonProps, text)}
 				</LinkWrapper>
+				{text && this.renderButton(buttonProps, text)}
 			</ListItemContainer>
 		);
 	}

--- a/src/molecules/list-item/image-list-item.js
+++ b/src/molecules/list-item/image-list-item.js
@@ -8,7 +8,8 @@ import {
 	ListItemHeader,
 	ArrowButton,
 	ArrowButtonLink,
-	Subtitle
+	Subtitle,
+	LinkWrapper
 } from 'atoms';
 
 class ImageListItem extends Component {
@@ -24,34 +25,43 @@ class ImageListItem extends Component {
 			text: PropTypes.string.isRequired,
 			nostyle: true
 		})
-	}
+	};
 
 	static defaultProps = {
 		buttonAttributes: {},
 		subtitle: null
-	}
+	};
 
-	renderButton = (buttonProps, text) => (
+	renderButton = (buttonProps, text) =>
 		buttonProps.onClick ? (
-			<ArrowButton {...buttonProps} mt={3}>{text}</ArrowButton>
+			<ArrowButton {...buttonProps} mt={3}>
+				{text}
+			</ArrowButton>
 		) : (
-			<ArrowButtonLink {...buttonProps} mt={3}>{text}</ArrowButtonLink>
-		)
-	)
+			<ArrowButtonLink {...buttonProps} mt={3}>
+				{text}
+			</ArrowButtonLink>
+		);
 
 	render() {
-		const { imageAttributes, buttonAttributes, title, subtitle, children, ...attrs } = this.props;
+		const { imageAttributes, buttonAttributes, title, subtitle, children, to, ...attrs } = this.props;
 		const { text, ...buttonProps } = buttonAttributes;
 
 		return (
 			<ListItemContainer {...attrs}>
-				<ListItemImage {...imageAttributes} />
-				<ListItemHeader mt={3}>
-					<ListItemTitle>{title}</ListItemTitle>
-					{subtitle && <Subtitle pb={1} color="#717171">{subtitle}</Subtitle>}
-				</ListItemHeader>
-				<ListItemBody>{children}</ListItemBody>
-				{text && this.renderButton(buttonProps, text)}
+				<LinkWrapper to={to}>
+					<ListItemImage {...imageAttributes} />
+					<ListItemHeader mt={3}>
+						<ListItemTitle>{title}</ListItemTitle>
+						{subtitle && (
+							<Subtitle pb={1} color="#717171">
+								{subtitle}
+							</Subtitle>
+						)}
+					</ListItemHeader>
+					<ListItemBody>{children}</ListItemBody>
+					{text && this.renderButton(buttonProps, text)}
+				</LinkWrapper>
 			</ListItemContainer>
 		);
 	}

--- a/src/molecules/list-item/image-list-item.js
+++ b/src/molecules/list-item/image-list-item.js
@@ -16,6 +16,7 @@ class ImageListItem extends Component {
 	static propTypes = {
 		title: PropTypes.string.isRequired,
 		subtitle: PropTypes.string,
+		to: PropTypes.string,
 		imageAttributes: PropTypes.shape({
 			src: PropTypes.string.isRequired,
 			alt: PropTypes.string.isRequired

--- a/src/molecules/list-item/list-item.js
+++ b/src/molecules/list-item/list-item.js
@@ -7,11 +7,14 @@ import {
 	ListItemHeader,
 	ArrowButton,
 	ArrowButtonLink,
-	Subtitle
+	Subtitle,
+	LinkWrapper
 } from 'atoms';
 
 class ListItem extends Component {
 	static propTypes = {
+		to: PropTypes.string,
+		href: PropTypes.string,
 		title: PropTypes.string.isRequired,
 		children: PropTypes.node.isRequired,
 		subtitle: PropTypes.string,
@@ -37,16 +40,18 @@ class ListItem extends Component {
 	)
 
 	render() {
-		const { title, children, buttonAttributes, subtitle, ...attrs } = this.props;
+		const { title, children, to, href, buttonAttributes, subtitle, ...attrs } = this.props;
 		const { text, ...buttonProps } = buttonAttributes;
 
 		return (
 			<ListItemContainer {...attrs}>
-				<ListItemHeader>
-					<ListItemTitle>{title}</ListItemTitle>
-					{subtitle && <Subtitle pb={1} color="#717171">{subtitle}</Subtitle>}
-				</ListItemHeader>
-				<ListItemBody>{children}</ListItemBody>
+				<LinkWrapper to={to} href={href}>
+					<ListItemHeader>
+						<ListItemTitle>{title}</ListItemTitle>
+						{subtitle && <Subtitle pb={1} color="#717171">{subtitle}</Subtitle>}
+					</ListItemHeader>
+					<ListItemBody>{children}</ListItemBody>
+				</LinkWrapper>
 				{text && this.renderButton(buttonProps, text)}
 			</ListItemContainer>
 		);

--- a/src/molecules/list-item/list-item.stories.js
+++ b/src/molecules/list-item/list-item.stories.js
@@ -19,6 +19,7 @@ storiesOf('Molecules/List Item', module)
 
 		return (
 			<ListItem
+				to={text('to', 'internal link')}
 				title={text('title', 'Physicians CME')}
 				buttonAttributes={object('button', buttonAttributes)}
 				type={select('background', ['white', 'gray', 'primary'], 'white')}
@@ -47,6 +48,7 @@ storiesOf('Molecules/List Item', module)
 
 		return (
 			<IconListItem
+				to={text('to', '/tester')}
 				title={text('title', 'Physicians CME')}
 				iconAttributes={object('icon', iconAttributes)}
 				buttonAttributes={object('button', buttonAttributes)}
@@ -77,7 +79,7 @@ storiesOf('Molecules/List Item', module)
 
 		return (
 			<ImageListItem
-				internalLink={text('to', '/')}
+				to={text('to', '/tester')}
 				title={text('title', 'Physicians CME')}
 				subtitle={text('subtitle', 'Something')}
 				imageAttributes={object('icon', imageAttributes)}

--- a/src/molecules/list-item/list-item.stories.js
+++ b/src/molecules/list-item/list-item.stories.js
@@ -22,13 +22,15 @@ storiesOf('Molecules/List Item', module)
 				title={text('title', 'Physicians CME')}
 				buttonAttributes={object('button', buttonAttributes)}
 				type={select('background', ['white', 'gray', 'primary'], 'white')}
-				subtitle={text('subtitle', 'Something')}
-			>
-				{text('description', `
+				subtitle={text('subtitle', 'Something')}>
+				{text(
+					'description',
+					`
 					We’re on a mission to provide mobile-friendly continuing education
 					taught by the world’s top skin care experts. Receive CE credits from anywhere
 					in the world, on any device.
-				`)}
+				`
+				)}
 			</ListItem>
 		);
 	})
@@ -49,13 +51,15 @@ storiesOf('Molecules/List Item', module)
 				iconAttributes={object('icon', iconAttributes)}
 				buttonAttributes={object('button', buttonAttributes)}
 				subtitle={text('subtitle', 'Something')}
-				type={select('background', ['white', 'grey', 'primary'], 'white')}
-			>
-				{text('description', `
+				type={select('background', ['white', 'grey', 'primary'], 'white')}>
+				{text(
+					'description',
+					`
 					We’re on a mission to provide mobile-friendly continuing education
 					taught by the world’s top skin care experts. Receive CE credits from anywhere
 					in the world, on any device.
-				`)}
+				`
+				)}
 			</IconListItem>
 		);
 	})
@@ -73,17 +77,20 @@ storiesOf('Molecules/List Item', module)
 
 		return (
 			<ImageListItem
+				to={text('to', '/')}
 				title={text('title', 'Physicians CME')}
 				subtitle={text('subtitle', 'Something')}
 				imageAttributes={object('icon', imageAttributes)}
 				buttonAttributes={object('button', buttonAttributes)}
-				type={select('background', ['white', 'grey', 'primary'], 'white')}
-			>
-				{text('description', `
+				type={select('background', ['white', 'grey', 'primary'], 'white')}>
+				{text(
+					'description',
+					`
 					We’re on a mission to provide mobile-friendly continuing education
 					taught by the world’s top skin care experts. Receive CE credits from anywhere
 					in the world, on any device.
-				`)}
+				`
+				)}
 			</ImageListItem>
 		);
 	});

--- a/src/molecules/list-item/list-item.stories.js
+++ b/src/molecules/list-item/list-item.stories.js
@@ -77,7 +77,7 @@ storiesOf('Molecules/List Item', module)
 
 		return (
 			<ImageListItem
-				to={text('to', '/')}
+				internalLink={text('to', '/')}
 				title={text('title', 'Physicians CME')}
 				subtitle={text('subtitle', 'Something')}
 				imageAttributes={object('icon', imageAttributes)}


### PR DESCRIPTION
This PR does the following:
- Adds a pointer cursor to LinkWrapper
- Changes styling on the ImageListItem Molecule (smaller font size and larger weight on title and allows for rows and smaller widths)
- Makes the ImageListItem an optional link
- Adds optional internal link to the story of ImageListItem
- Adds display attribute to SectionBody Atom
- Adds external links to LinkWrapper and ImageListItem Molecule

Steps to Test:

- Run storybook.
- Check that a pointer cursor appears in the LinkWrapper Atom.
- Check that you like the way the ImageListItem Molecule appears in its story.
- Check that ImageListItem has an option to add a 'to' in the knobs.
